### PR TITLE
Master to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           poetry run flake8 . --count --exit-zero --max-complexity=10 --statistics
       - name: Type check with mypy
         run: |
-          mypy .
+          poetry run mypy .
       - name: Test with pytest
         run: |
           poetry run pytest tests --cov ./seq2rel --cov-report=xml --cov-config=./.coveragerc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 ![build](https://github.com/JohnGiorgi/seq2rel/workflows/build/badge.svg)
+[![codecov](https://codecov.io/gh/JohnGiorgi/seq2rel/branch/master/graph/badge.svg)](https://codecov.io/gh/JohnGiorgi/seq2rel)
+[![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
+![GitHub](https://img.shields.io/github/license/JohnGiorgi/seq2rel?color=blue)
 
 # seq2rel
 

--- a/seq2rel/metrics/fbeta_measure_seq2rel.py
+++ b/seq2rel/metrics/fbeta_measure_seq2rel.py
@@ -11,7 +11,7 @@ class FBetaMeasureSeq2Rel(FBetaMeasure):
     """A thin wrapper around FBetaMeasure, which computes the precision, recall and F-measure for
     the output a Seq2Rel model. Besides `labels` and `ordered_ents`, the parameters are the same as
     the parent class. For details, please see:
-    [FBetaMeasure](https://github.com/allenai/allennlp/blob/master/allennlp/training/metrics/fbeta_measure.py)
+    [FBetaMeasure](https://github.com/allenai/allennlp/blob/main/allennlp/training/metrics/fbeta_measure.py)
 
     # Parameters
 

--- a/seq2rel/models/copynet_seq2rel.py
+++ b/seq2rel/models/copynet_seq2rel.py
@@ -21,7 +21,7 @@ class CopyNetSeq2Rel(CopyNetSeq2Seq):
     This is a thin wrapper around `CopyNetSeq2Seq` to provide any of the modifications necessary to
     use the model for information extraction. Besides `target_tokenizer` and `sequence_based_metric`
     the arguments are identical to `CopyNetSeq2Seq`. For details, please see:
-    [`CopyNetSeq2Seq`](https://github.com/allenai/allennlp-models/blob/master/allennlp_models/generation/models/copynet_seq2seq.py),
+    [`CopyNetSeq2Seq`](https://github.com/allenai/allennlp-models/blob/main/allennlp_models/generation/models/copynet_seq2seq.py),
 
     # Parameters
 


### PR DESCRIPTION
# Overview

Changes `master` --> `main` everywhere it counts. In particular, this should fix our build config which was not running previously.