### PR TITLE
Update ci configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: build
+name: ci
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -45,13 +45,11 @@ jobs:
         run: |
           poetry run pytest tests --cov-report=xml --cov ./seq2rel --cov-config=.coveragerc
       - name: Upload coverage to Codecov
-        # We don't want to push coverge for every job in the matrix.
-        # Rather arbitrarily, choose to push on Ubuntu with Python 3.9.
-        if: matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' && (github.event_name == 'push' || github.event_name == 'pull_request')
         uses: codecov/codecov-action@v1.4.1
         with:
           file: ./coverage.xml
-          # Ignore codecov failures as the codecov server is not very reliable but we don't
-          # want to report a failure in the github UI just because the coverage report failed
-          # to be published.
+          # Ignore codecov failures as the codecov server is not
+          # very reliable but we don't want to report a failure
+          # in the github UI just because the coverage report failed to
+          # be published.
           fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # seq2rel
 
-![build](https://github.com/JohnGiorgi/seq2rel/workflows/build/badge.svg)
+[![ci](https://github.com/JohnGiorgi/seq2rel/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JohnGiorgi/seq2rel/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/JohnGiorgi/seq2rel/branch/main/graph/badge.svg?token=RKJ7EV4WQK)](https://codecov.io/gh/JohnGiorgi/seq2rel)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 ![GitHub](https://img.shields.io/github/license/JohnGiorgi/seq2rel?color=blue)
@@ -9,7 +9,7 @@ A Python package that makes it easy to use sequence-to-sequence (seq2seq) learni
 
 ## Installation
 
-This repository requires Python 3.8 or later. The preferred way to install is via pip:
+This repository requires Python 3.7.1 or later. The preferred way to install is via pip:
 
 ```
 pip install seq2rel

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,9 @@ seq2rel
 =======
 
 
-.. image:: https://github.com/JohnGiorgi/seq2rel/workflows/build/badge.svg
-   :target: https://github.com/JohnGiorgi/seq2rel/workflows/build/badge.svg
-   :alt: build
+.. image:: https://github.com/JohnGiorgi/seq2rel/actions/workflows/ci.yml/badge.svg?branch=main
+   :target: https://github.com/JohnGiorgi/seq2rel/actions/workflows/ci.yml
+   :alt: ci
 
 
 .. image:: https://codecov.io/gh/JohnGiorgi/seq2rel/branch/main/graph/badge.svg?token=RKJ7EV4WQK
@@ -28,7 +28,7 @@ A Python package that makes it easy to use sequence-to-sequence (seq2seq) learni
 Installation
 ------------
 
-This repository requires Python 3.8 or later. The preferred way to install is via pip:
+This repository requires Python 3.7.1 or later. The preferred way to install is via pip:
 
 .. code-block::
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -224,12 +224,24 @@ moreorless = ">=0.2.0"
 volatile = "*"
 
 [[package]]
+name = "cached-property"
+version = "1.5.2"
+description = "A decorator for caching properties in classes."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "catalogue"
 version = "2.0.3"
 description = "Super lightweight function registries for your library"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = {version = ">=0.5", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "cerberus"
@@ -301,7 +313,9 @@ python-versions = ">=3.5"
 [package.dependencies]
 attrs = ">=16.3.0"
 colorama = ">=0.3.7"
+importlib-metadata = {version = ">=1.6.0", markers = "python_version < \"3.8\""}
 pyperclip = ">=1.6"
+pyreadline = {version = "*", markers = "sys_platform == \"win32\" and python_version < \"3.8\""}
 pyreadline3 = {version = "*", markers = "sys_platform == \"win32\" and python_version >= \"3.8\""}
 wcwidth = ">=0.1.7"
 
@@ -645,6 +659,7 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
@@ -696,7 +711,9 @@ optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
+cached-property = {version = "*", markers = "python_version < \"3.8\""}
 numpy = [
+    {version = ">=1.14.5", markers = "python_version == \"3.7\""},
     {version = ">=1.17.5", markers = "python_version == \"3.8\""},
     {version = ">=1.19.3", markers = "python_version >= \"3.9\""},
 ]
@@ -756,6 +773,22 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "importlib-metadata"
+version = "4.0.1"
+description = "Read metadata from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -808,6 +841,9 @@ description = "Python library for serializing any arbitrary object graph into JS
 category = "main"
 optional = false
 python-versions = ">=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
@@ -1049,6 +1085,9 @@ category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
 [package.extras]
 dev = ["pre-commit", "tox"]
 
@@ -1073,6 +1112,7 @@ optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 wcwidth = "*"
 
 [package.extras]
@@ -1167,6 +1207,14 @@ optional = true
 python-versions = "*"
 
 [[package]]
+name = "pyreadline"
+version = "2.1"
+description = "A python implmementation of GNU readline."
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
 name = "pyreadline3"
 version = "3.3"
 description = "A python implementation of GNU readline."
@@ -1186,6 +1234,7 @@ python-versions = ">=3.6"
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0.0a1"
@@ -1437,6 +1486,7 @@ srsly = ">=2.4.1,<3.0.0"
 thinc = ">=8.0.3,<8.1.0"
 tqdm = ">=4.38.0,<5.0.0"
 typer = ">=0.3.0,<0.4.0"
+typing-extensions = {version = ">=3.7.4,<4.0.0.0", markers = "python_version < \"3.8\""}
 wasabi = ">=0.8.1,<1.1.0"
 
 [package.extras]
@@ -1476,6 +1526,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 
 [package.dependencies]
 greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 aiomysql = ["greenlet (!=0.4.17)", "aiomysql"]
@@ -1517,6 +1568,7 @@ optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
+importlib-metadata = {version = ">=1.7.0", markers = "python_version < \"3.8\""}
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
@@ -1559,6 +1611,7 @@ numpy = ">=1.15.0"
 preshed = ">=3.0.2,<3.1.0"
 pydantic = ">=1.7.1,<1.8.0"
 srsly = ">=2.4.0,<3.0.0"
+typing-extensions = {version = ">=3.7.4.1,<4.0.0.0", markers = "python_version < \"3.8\""}
 wasabi = ">=0.8.1,<1.1.0"
 
 [package.extras]
@@ -1647,6 +1700,7 @@ python-versions = ">=3.6.0"
 
 [package.dependencies]
 filelock = "*"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 numpy = "*"
 packaging = "*"
 regex = "!=2019.12.17"
@@ -1808,6 +1862,7 @@ python-versions = ">=3.6"
 [package.dependencies]
 idna = ">=2.0"
 multidict = ">=4.0"
+typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "yaspin"
@@ -1817,13 +1872,25 @@ category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
+[[package]]
+name = "zipp"
+version = "3.4.1"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
 [extras]
 optuna = ["allennlp-optuna"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.8"
-content-hash = "b9dc17647e9b653120f603dadfd1a1d0cae55a1f9b2c788134863ae7ec630499"
+python-versions = "^3.7.1"
+content-hash = "23af6155eae9f0267b6b0fc84461d332d337c54b193a5db6e0b7fbcc7a4f054a"
 
 [metadata.files]
 aiofiles = [
@@ -1934,6 +2001,10 @@ botocore = [
 bowler = [
     {file = "bowler-0.9.0-py3-none-any.whl", hash = "sha256:0351839e9917765be694aa52c99ea784dc1286c9bdd6fd066b810097fc273e1b"},
     {file = "bowler-0.9.0.tar.gz", hash = "sha256:cdb85ce2e7bd545802a15d755d1daf2b6a125429355c50d2019a9f35d63e45db"},
+]
+cached-property = [
+    {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
+    {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
 ]
 catalogue = [
     {file = "catalogue-2.0.3-py3-none-any.whl", hash = "sha256:ea9626fe3dffe2c17c2e8dad9edf689acb08b980babfa96f698687305cc0a194"},
@@ -2211,6 +2282,10 @@ hypothesis = [
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-4.0.1-py3-none-any.whl", hash = "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d"},
+    {file = "importlib_metadata-4.0.1.tar.gz", hash = "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -2554,6 +2629,11 @@ pyparsing = [
 ]
 pyperclip = [
     {file = "pyperclip-1.8.2.tar.gz", hash = "sha256:105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57"},
+]
+pyreadline = [
+    {file = "pyreadline-2.1.win-amd64.exe", hash = "sha256:9ce5fa65b8992dfa373bddc5b6e0864ead8f291c94fbfec05fbd5c836162e67b"},
+    {file = "pyreadline-2.1.win32.exe", hash = "sha256:65540c21bfe14405a3a77e4c085ecfce88724743a4ead47c66b84defcf82c32e"},
+    {file = "pyreadline-2.1.zip", hash = "sha256:4530592fc2e85b25b1a9f79664433da09237c1a270e4d78ea5aa3a2c7229e2d1"},
 ]
 pyreadline3 = [
     {file = "pyreadline3-3.3-py3-none-any.whl", hash = "sha256:0003fd0079d152ecbd8111202c5a7dfa6a5569ffd65b235e45f3c2ecbee337b4"},
@@ -3122,4 +3202,8 @@ yarl = [
 yaspin = [
     {file = "yaspin-1.5.0-py2.py3-none-any.whl", hash = "sha256:10348ecc3b9c1f5a0c83390e0b892b62d3f3dae300d0c74e01ce72f8b032406c"},
     {file = "yaspin-1.5.0.tar.gz", hash = "sha256:d8fc9bc1c8be225877ea6e2e08fec96c2b52e233525a5c40b92d373f015439c6"},
+]
+zipp = [
+    {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},
+    {file = "zipp-3.4.1.tar.gz", hash = "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 exclude = ["tests", "training_config"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7.1"
 typer = {extras = ["all"], version = "^0.3.2"}
 allennlp = "^1.4.1"
 allennlp-models = "^1.4.1"

--- a/setup.py
+++ b/setup.py
@@ -11,58 +11,70 @@ except ImportError:
 
 import os.path
 
-readme = ''
+readme = ""
 here = os.path.abspath(os.path.dirname(__file__))
-readme_path = os.path.join(here, 'README.rst')
+readme_path = os.path.join(here, "README.rst")
 if os.path.exists(readme_path):
-    with open(readme_path, 'rb') as stream:
-        readme = stream.read().decode('utf8')
+    with open(readme_path, "rb") as stream:
+        readme = stream.read().decode("utf8")
 
 setup(
     long_description=readme,
-    name='seq2rel',
-    version='0.1.0',
-    description='A Python package that makes it easy to use sequence-to-sequence (seq2seq) learning for information extraction.',
-    python_requires='==3.*,>=3.8.0',
+    name="seq2rel",
+    version="0.1.0",
+    description="A Python package that makes it easy to use sequence-to-sequence (seq2seq) learning for information extraction.",
+    python_requires="==3.*,>=3.7.1",
     project_urls={
         "homepage": "https://github.com/johngiorgi/seq2rel",
-        "repository": "https://github.com/johngiorgi/seq2rel"
+        "repository": "https://github.com/johngiorgi/seq2rel",
     },
-    author='johngiorgi',
-    author_email='johnmgiorgi@gmail.com',
-    license='Apache-2.0',
-    keywords='named entity recognition relation extraction information extraction seq2seq',
+    author="johngiorgi",
+    author_email="johnmgiorgi@gmail.com",
+    license="Apache-2.0",
+    keywords="named entity recognition relation extraction information extraction seq2seq",
     classifiers=[
-        'Development Status :: 1 - Planning', 'Environment :: Console',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Topic :: Scientific/Engineering :: Artificial Intelligence',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Typing :: Typed'
+        "Development Status :: 1 - Planning",
+        "Environment :: Console",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Typing :: Typed",
     ],
     packages=[
-        'seq2rel', 'seq2rel.common', 'seq2rel.data',
-        'seq2rel.data.dataset_readers', 'seq2rel.metrics', 'seq2rel.models',
-        'seq2rel.modules', 'seq2rel.modules.attention'
+        "seq2rel",
+        "seq2rel.common",
+        "seq2rel.data",
+        "seq2rel.data.dataset_readers",
+        "seq2rel.metrics",
+        "seq2rel.models",
+        "seq2rel.modules",
+        "seq2rel.modules.attention",
     ],
     package_dir={"": "."},
     package_data={},
     install_requires=[
-        'allennlp==1.*,>=1.4.1', 'allennlp-models==1.*,>=1.4.1',
-        'typer[all]==0.*,>=0.3.2', 'validators==0.*,>=0.18.2'
+        "allennlp==1.*,>=1.4.1",
+        "allennlp-models==1.*,>=1.4.1",
+        "typer[all]==0.*,>=0.3.2",
+        "validators==0.*,>=0.18.2",
     ],
     extras_require={
         "dev": [
-            "black==20.*,>=20.8.0.b1", "codecov==2.*,>=2.1.10",
-            "coverage==5.*,>=5.5.0", "dephell[full]==0.*,>=0.8.3",
-            "flake8==3.*,>=3.9.1", "hypothesis==6.*,>=6.10.0",
-            "mypy==0.*,>=0.812.0", "pytest==6.*,>=6.2.3",
-            "pytest-cov==2.*,>=2.11.1"
+            "black==20.*,>=20.8.0.b1",
+            "codecov==2.*,>=2.1.10",
+            "coverage==5.*,>=5.5.0",
+            "dephell[full]==0.*,>=0.8.3",
+            "flake8==3.*,>=3.9.1",
+            "hypothesis==6.*,>=6.10.0",
+            "mypy==0.*,>=0.812.0",
+            "pytest==6.*,>=6.2.3",
+            "pytest-cov==2.*,>=2.11.1",
         ],
-        "optuna": ["allennlp-optuna==0.*,>=0.1.4"]
+        "optuna": ["allennlp-optuna==0.*,>=0.1.4"],
     },
 )


### PR DESCRIPTION
A small PR that does two things:

- Rename `build` to `ci` everywhere. I think this is clearer.
- Support python>=3.7.1
- Get codecov reports on PRs