### PR TITLE
Better rel and ent parsing

### DIFF
--- a/seq2rel/common/util.py
+++ b/seq2rel/common/util.py
@@ -3,8 +3,8 @@ from typing import Any, Dict, List, Union
 
 END_OF_REL_SYMBOL = "@EOR@"
 COREF_SEP_SYMBOL = ";"
-ENT_PATTERN = re.compile(r"(?:\s?)(.*?)(?:\s?)@([A-Z][A-Z0-9]*)\b[^@]*@")
-REL_PATTERN = re.compile(fr"@([A-Z][A-Z0-9]*)\b[^@]*@(.*?){END_OF_REL_SYMBOL}")
+ENT_PATTERN = re.compile(r"(?:\s?)(.*?)(?:\s?)@([^\s]*)\b[^@]*@")
+REL_PATTERN = re.compile(fr"@([^\s]*)\b[^@]*@(.*?){END_OF_REL_SYMBOL}")
 
 
 def sanitize_text(text: str, lowercase: bool = False) -> str:

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -29,6 +29,7 @@ def test_deserialize_annotation() -> None:
     # - non-empty string with no relation
     # - a single relation string
     # - a multiple relation string
+    # - a more complicated relation type with non-alpha-numeric characters
     serialized_annotations = [
         "",
         "I don't contain anything of interest!",
@@ -38,6 +39,7 @@ def test_deserialize_annotation() -> None:
             " @ADE@ latanoprost @DRUG@ cystoid macula edema @EFFECT@ @EOR@"
             " @CID@ methamphetamine; meth @CHEMICAL@ psychosis; psychotic disorders @DISEASE@ @EOR@"
         ),
+        "@LOCATED_IN_THE_ADMINISTRATIVE_TERRITORIAL_ENTITY@ pasay city @LOC@ metro manila @LOC@ @EOR@",
     ]
 
     # Check that we can call the function of a list of strings
@@ -55,6 +57,11 @@ def test_deserialize_annotation() -> None:
                     ("methamphetamine; meth", "CHEMICAL"),
                     ("psychosis; psychotic disorders", "DISEASE"),
                 )
+            ],
+        },
+        {
+            "LOCATED_IN_THE_ADMINISTRATIVE_TERRITORIAL_ENTITY": [
+                (("pasay city", "LOC"), ("metro manila", "LOC"))
             ],
         },
     ]


### PR DESCRIPTION
This PR tweaks the regex used to parse entities and relations from the serialized strings. Mainly, it now allows the class label to be anything other than a space. This was important for cases like DocRED, where relation names where multi-word strings and so I would join them with `"_"`, like `"APPLIES_TO_JURISDICTION"`.

I updated the unit tests to contain an example with underscores.