### PR TITLE
:bug: Fix broken ADE model

### DIFF
--- a/seq2rel/seq2rel.py
+++ b/seq2rel/seq2rel.py
@@ -37,7 +37,7 @@ class Seq2Rel:
     input_text = "Ciprofloxacin-induced renal insufficiency in cystic fibrosis."
 
     seq2rel(input_text)
-    >>> ['<ADE> ciprofloxacin <DRUG> renal insufficiency <EFFECT> </ADE>']
+    >>> ['@ADE@ ciprofloxacin @DRUG@ renal insufficiency @EFFECT@ @EOR@']
     ```
 
     # Parameters
@@ -75,9 +75,12 @@ class Seq2Rel:
             If given, the `inputs` will be batched before embedding.
         """
         if isinstance(inputs, str):
-            if Path(inputs).is_file() or url(inputs):
-                inputs = Path(cached_path(inputs)).read_text().split("\n")
-            else:
+            try:
+                if Path(inputs).is_file() or url(inputs):
+                    inputs = Path(cached_path(inputs)).read_text().split("\n")
+                else:
+                    inputs = [inputs]
+            except OSError:
                 inputs = [inputs]
 
         if batch_size is None:

--- a/seq2rel/seq2rel.py
+++ b/seq2rel/seq2rel.py
@@ -74,10 +74,13 @@ class Seq2Rel:
         batch_size : `int`, optional
             If given, the `inputs` will be batched before embedding.
         """
+        # TODO: This is ugly, clean it up.
         if isinstance(inputs, str):
             try:
                 if Path(inputs).is_file() or url(inputs):
                     inputs = Path(cached_path(inputs)).read_text().strip().split("\n")
+                else:
+                    inputs = [inputs]  # type: ignore
             except OSError:
                 inputs = [inputs]  # type: ignore
 

--- a/seq2rel/seq2rel.py
+++ b/seq2rel/seq2rel.py
@@ -75,12 +75,9 @@ class Seq2Rel:
             If given, the `inputs` will be batched before embedding.
         """
         if isinstance(inputs, str):
-            try:
-                if Path(inputs).is_file() or url(inputs):
-                    inputs = Path(cached_path(inputs)).read_text().split("\n")
-                else:
-                    inputs = [inputs]
-            except OSError:
+            if Path(inputs).is_file() or url(inputs):
+                inputs = Path(cached_path(inputs)).read_text().split("\n")
+            else:
                 inputs = [inputs]
 
         if batch_size is None:

--- a/seq2rel/seq2rel.py
+++ b/seq2rel/seq2rel.py
@@ -75,10 +75,11 @@ class Seq2Rel:
             If given, the `inputs` will be batched before embedding.
         """
         if isinstance(inputs, str):
-            if Path(inputs).is_file() or url(inputs):
-                inputs = Path(cached_path(inputs)).read_text().split("\n")
-            else:
-                inputs = [inputs]
+            try:
+                if Path(inputs).is_file() or url(inputs):
+                    inputs = Path(cached_path(inputs)).read_text().strip().split("\n")
+            except OSError:
+                inputs = [inputs]  # type: ignore
 
         if batch_size is None:
             batch_size = len(inputs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,11 @@ def ade_examples() -> Tuple[List[str], List[str]]:
         "Acute myocardial infarction due to coronary spasm associated with L-thyroxine therapy.",
     ]
     annotations = [
-        "<ADE> vincristine <DRUG> cranial polyneuropathy <EFFECT> </ADE>",
-        "<ADE> diazepam <DRUG> seizures <EFFECT> </ADE>",
+        "@ADE@ vincristine @DRUG@ cranial polyneuropathy @EFFECT@ @EOR@",
+        "@ADE@ diazepam @DRUG@ seizures @EFFECT@ @EOR@",
         (
-            "<ADE> l - thyroxine <DRUG> acute myocardial infarction <EFFECT> </ADE>"
-            " <ADE> l - thyroxine <DRUG> coronary spasm <EFFECT> </ADE>"
+            "@ADE@ l - thyroxine @DRUG@ acute myocardial infarction @EFFECT@ @EOR@"
+            " @ADE@ l - thyroxine @DRUG@ coronary spasm @EFFECT@ @EOR@"
         ),
     ]
     return texts, annotations


### PR DESCRIPTION
The ADE model was pretrained with AllenNLP <2.0, and was incompatible with the new AllenNLP 2.0+ codebase. This PR fixes that.

Closes #64.