### PR TITLE
Use more itertools for batching

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2127,7 +2127,7 @@ optuna = ["allennlp-optuna"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "2f7dd80dec9bdc7fc672be236db0ac75e0d7a0f1e0559a21d9da6d20596f0bc2"
+content-hash = "235b6858a396c1555bc4ba5c407a57d6231e5759af2cddfe38556121da198429"
 
 [metadata.files]
 aiofiles = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ allennlp = "^2.4.0"
 allennlp-models = "^2.4.0"
 allennlp-optuna = { version = "^0.1.5", optional = true }
 validators = "^0.18.2"
+more-itertools = "^8.7.0"
 
 [tool.poetry.extras]
 optuna = ["allennlp-optuna"]

--- a/seq2rel/seq2rel.py
+++ b/seq2rel/seq2rel.py
@@ -6,6 +6,7 @@ from allennlp.common import util as common_util
 from allennlp.common.file_utils import cached_path
 from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
+from more_itertools import chunked
 from validators.url import url
 
 from seq2rel.common.util import sanitize_text
@@ -88,10 +89,8 @@ class Seq2Rel:
             batch_size = len(inputs)
 
         predicted_strings = []
-        for i in range(0, len(inputs), batch_size):
-            batch_json = [
-                {"source": sanitize_text(input_)} for input_ in inputs[i : i + batch_size]
-            ]
+        for batch in chunked(inputs, batch_size):
+            batch_json = [{"source": sanitize_text(example)} for example in batch]
             outputs = self._predictor.predict_batch_json(batch_json)
             outputs = [output[self._output_dict_field] for output in outputs]
             predicted_strings.extend(outputs)


### PR DESCRIPTION
A small PR that uses the `chunked` function of `more-itertools` to clean up the batching mechanism in `Seq2Rel`