### PR TITLE
Add average length metric as diagnostic

### DIFF
--- a/seq2rel/metrics/__init__.py
+++ b/seq2rel/metrics/__init__.py
@@ -1,1 +1,2 @@
+from seq2rel.metrics.average_length import AverageLength
 from seq2rel.metrics.fbeta_measure_seq2rel import F1MeasureSeq2Rel, FBetaMeasureSeq2Rel

--- a/seq2rel/metrics/average_length.py
+++ b/seq2rel/metrics/average_length.py
@@ -1,0 +1,37 @@
+from typing import List, Dict
+from allennlp.training.metrics import Metric
+
+
+@Metric.register("average_length")
+class AverageLength(Metric):
+    """Compute the average length of the decoded and target sequences. This is useful as a
+    diagnostic. E.g., if the average length of decoded sequences is longer than target sequences,
+    you may want to add or increase the length penalty (and vice versa).
+    """
+
+    supports_distributed = False
+
+    def __init__(self):
+        self._decoded_lengths = []
+        self._target_lengths = []
+
+    def __call__(self, predictions: List[List[str]], targets: List[List[str]]) -> None:
+        for pred, target in zip(predictions, targets):
+            self._decoded_lengths.append(len(pred))
+            self._target_lengths.append(len(target))
+
+    def get_metric(self, reset: bool = False) -> Dict[str, float]:
+        decoded_mean_length = sum(self._decoded_lengths) / len(self._decoded_lengths)
+        target_mean_length = sum(self._target_lengths) / len(self._target_lengths)
+
+        if reset:
+            self.reset()
+
+        return {
+            "decoded_mean_length": round(decoded_mean_length, 2),
+            "target_mean_length": round(target_mean_length, 2),
+        }
+
+    def reset(self) -> None:
+        self._decoded_lengths = []
+        self._target_lengths = []

--- a/seq2rel/metrics/average_length.py
+++ b/seq2rel/metrics/average_length.py
@@ -30,6 +30,7 @@ class AverageLength(Metric):
         return {
             "decoded_mean_length": round(decoded_mean_length, 2),
             "target_mean_length": round(target_mean_length, 2),
+            "ratio": round(decoded_mean_length / target_mean_length, 2),
         }
 
     def reset(self) -> None:

--- a/test_fixtures/copynet_seq2rel/experiment.jsonnet
+++ b/test_fixtures/copynet_seq2rel/experiment.jsonnet
@@ -72,8 +72,11 @@ local TARGET_TOKENIZER = {
             },
         },
         "target_tokenizer": TARGET_TOKENIZER,
+        "token_based_metric": {
+            "type": "seq2rel.metrics.AverageLength"
+        },
         "sequence_based_metric": {
-            "type": "seq2rel.metrics.fbeta_measure_seq2rel.F1MeasureSeq2Rel",
+            "type": "seq2rel.metrics.F1MeasureSeq2Rel",
             "labels": labels,
             "average": "micro"
         },

--- a/tests/metrics/test_average_length.py
+++ b/tests/metrics/test_average_length.py
@@ -17,8 +17,9 @@ class TestAverageLength(AverageLengthTestCase):
         average_length = AverageLength()
         average_length(self.predictions, self.targets)
         expected = {
-            "decoded_mean_length": self.decoded_mean_length,
-            "target_mean_length": self.target_mean_length,
+            "decoded_mean_length": round(self.decoded_mean_length, 2),
+            "target_mean_length": round(self.target_mean_length, 2),
+            "ratio": round(self.decoded_mean_length / self.target_mean_length, 2),
         }
         actual = average_length.get_metric()
         assert actual == expected

--- a/tests/metrics/test_average_length.py
+++ b/tests/metrics/test_average_length.py
@@ -1,0 +1,24 @@
+from seq2rel.metrics.average_length import AverageLength
+
+
+class AverageLengthTestCase:
+    def setup_method(self):
+        self.predictions = ["They may take us, but they’ll never take our freedom!".split()]
+        self.targets = ["They may take our lives, but they’ll never take our freedom!".split()]
+        self.decoded_mean_length = len(self.predictions[0]) / len(self.predictions)
+        self.target_mean_length = len(self.targets[0]) / len(self.targets)
+
+
+class TestAverageLength(AverageLengthTestCase):
+    def setup_method(self):
+        super().setup_method()
+
+    def test_average_length(self):
+        average_length = AverageLength()
+        average_length(self.predictions, self.targets)
+        expected = {
+            "decoded_mean_length": self.decoded_mean_length,
+            "target_mean_length": self.target_mean_length,
+        }
+        actual = average_length.get_metric()
+        assert actual == expected

--- a/tests/metrics/test_fbeta_measure_seq2rel.py
+++ b/tests/metrics/test_fbeta_measure_seq2rel.py
@@ -6,7 +6,7 @@ from seq2rel.metrics.fbeta_measure_seq2rel import FBetaMeasureSeq2Rel, F1Measure
 from torch.testing import assert_allclose
 
 
-class MetricsTestCase:
+class FBetaMeasureSeq2RelTestCase:
     def setup_method(self):
         self.labels = ["PHYSICAL", "GENETIC"]
         self.predictions = [
@@ -46,7 +46,7 @@ class MetricsTestCase:
         self.desired_fscores = desired_fscores
 
 
-class TestFBetaMeasureSeq2Rel(MetricsTestCase):
+class TestFBetaMeasureSeq2Rel(FBetaMeasureSeq2RelTestCase):
     """Tests for FBetaMeasureSeq2Rel. Note that for now, these tests assume
     that entities in a relation have an inherent order.
 
@@ -140,7 +140,7 @@ class TestFBetaMeasureSeq2Rel(MetricsTestCase):
         assert_allclose(fscores, micro_fscore)
 
 
-class TestF1MeasureSeq2Rel(MetricsTestCase):
+class TestF1MeasureSeq2Rel(FBetaMeasureSeq2RelTestCase):
     """Tests for F1MeasureSeq2Rel. Because F1MeasureSeq2Rel is a just a wrapper on
     FBetaMeasureSeq2Rel and introduces no new logic, this exists mainly just to ensure we
     can instantiate F1MeasureSeq2Rel without error.
@@ -154,6 +154,3 @@ class TestF1MeasureSeq2Rel(MetricsTestCase):
     ):
         fbeta = F1MeasureSeq2Rel(labels=self.labels)
         assert fbeta._beta == 1.0
-
-
-# %%


### PR DESCRIPTION
This PR adds a token-based metric, `AverageLength` that simply reports the average length of the decoded and target sequences and their ratio. This is not meant to be used as a metric to make hyperparameter decisions but as a diagnostic. For example, if the ratio is large and positive, it may be worth increasing the length penalty (and vice versa).