### PR TITLE
Drop invalid relations

### DIFF
--- a/seq2rel/common/util.py
+++ b/seq2rel/common/util.py
@@ -49,8 +49,8 @@ def deserialize_annotations(
             raw_clusters = tuple(CLUSTER_PATTERN.findall(rel_string))
             # Normalizes clusters so that evaluation is insensitive to order, case and duplicates.
             clusters = _normalize_clusters(raw_clusters)  # type: ignore
-            # A relation must contain at least to entities. We purposfully do not retain
-            # those that don't, otherwise that would be counted as a false-positive.
+            # A relation must contain at least to entities. These are easy to detect at training
+            # and at inference, so we purposfully drop them.
             if len(clusters) < 2:
                 continue
             if rel_label in deserialized[-1]:

--- a/seq2rel/common/util.py
+++ b/seq2rel/common/util.py
@@ -49,6 +49,10 @@ def deserialize_annotations(
             raw_clusters = tuple(CLUSTER_PATTERN.findall(rel_string))
             # Normalizes clusters so that evaluation is insensitive to order, case and duplicates.
             clusters = _normalize_clusters(raw_clusters)  # type: ignore
+            # A relation must contain at least to entities. We purposfully do not retain
+            # those that don't, otherwise that would be counted as a false-positive.
+            if len(clusters) < 2:
+                continue
             if rel_label in deserialized[-1]:
                 # Don't retain duplicates
                 if clusters not in deserialized[-1][rel_label]:

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -26,6 +26,7 @@ def test_deserialize_annotation() -> None:
     # Test:
     # - the empty string
     # - non-empty string with no relation
+    # - non-empty string with an invalid relation
     # - a single relation string
     # - a multiple relation string
     # - a more complicated relation type with non-alpha-numeric characters in the special tokens
@@ -33,6 +34,7 @@ def test_deserialize_annotation() -> None:
     serialized_annotations = [
         "",
         "I don't contain anything of interest!",
+        "@ADE@ fenoprofen @DRUG@ @EOR@",
         "@ADE@ fenoprofen @DRUG@ pure red cell aplasia @EFFECT@ @EOR@",
         (
             "@ADE@ bimatoprost @DRUG@ cystoid macula edema @EFFECT@ @EOR@"
@@ -47,6 +49,7 @@ def test_deserialize_annotation() -> None:
 
     # Check that we can call the function on a list of strings
     expected = [
+        {},
         {},
         {},
         {"ADE": [((("fenoprofen",), "DRUG"), (("pure red cell aplasia",), "EFFECT"))]},


### PR DESCRIPTION
This is a small weak to `deserialize_annotations` that drops any decoded relations with less than two predicted entities. If these are retained, they always counted as a false-positive. Because they are easy to detect, it makes sense to drop them, which leads to a more accurate F1-score. I have tested this code on the BC5CDR and it leads to about a +0.5% boost in performance.