### PR TITLE
Make the spacing around coref mentions consistant

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -74,7 +74,7 @@ def process_ent(text: str, ents: Tuple[str, ...]) -> str:
 
     ent_text = f"{matched_ents[0]}"
     if matched_ents[1:]:
-        ent_text += f"{util.COREF_SEP_SYMBOL} {util.COREF_SEP_SYMBOL.join(matched_ents[1:])}"
+        ent_text += f"{util.COREF_SEP_SYMBOL} {f'{util.COREF_SEP_SYMBOL} '.join(matched_ents[1:])}"
     return ent_text
 
 


### PR DESCRIPTION
A quick PR that makes the spacing around coreferent mentions in the demo consistant.