### PR TITLE
Head+tail truncation

### DIFF
--- a/seq2rel/dataset_reader.py
+++ b/seq2rel/dataset_reader.py
@@ -1,9 +1,12 @@
 import logging
+from math import floor
+from typing import Optional
 
 from allennlp.data.dataset_readers.dataset_reader import DatasetReader
 from allennlp.data.instance import Instance
 from allennlp_models.generation.dataset_readers import CopyNetDatasetReader
 from overrides import overrides
+from allennlp.data.tokenizers import PretrainedTransformerTokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -12,15 +15,34 @@ logger = logging.getLogger(__name__)
 class Seq2RelDatasetReader(CopyNetDatasetReader):
     """
     This is a thin wrapper around `CopyNetDatasetReader` to provide any of the modifications
-    necessary to use the dataset reader for information extraction. The arguments are identical to
-    `CopyNetSeq2Seq`. For details, please see:
-    [`CopyNetSeq2Seq`](https://github.com/allenai/allennlp-models/blob/main/allennlp_models/generation/dataset_readers/copynet_seq2seq.py),
+    necessary to use the dataset reader for information extraction. For details, please see:
+    [`CopyNetSeq2Seq`](https://github.com/allenai/allennlp-models/blob/main/allennlp_models/generation/dataset_readers/copynet_seq2seq.py).
+
+    # Parameters
+
+    max_length : `int`, optional (default = None)
+        The maximum length of the source sequences. If not None, the source sequences will be
+        truncated to this length by concatenating the first 75% and last 25% `max_length` tokens.
+        This is known as head+tail truncation. See https://arxiv.org/abs/1905.05583 for details.
+        Note: This only works correctly if the source tokenizer is a `PretrainedTransformerTokenizer`.
     """
+
+    def __init__(self, max_length: Optional[int] = None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._max_length = max_length
 
     @overrides
     def text_to_instance(
         self, source_string: str, target_string: str = None, _id: str = None
     ) -> Instance:  # type: ignore
+
+        if self._max_length is not None:
+            if not isinstance(self._source_tokenizer, PretrainedTransformerTokenizer):
+                raise ValueError(
+                    "max_length was provided to Seq2RelDatasetReader. source_tokenizer must be a"
+                    " PretrainedTransformerTokenizer."
+                )
+            source_string = self._head_tail_truncation(source_string)
         # We have to add a space in front of the source/target strings in order to achieve
         # consistant tokenization with certain tokenizers, like GPT. Enforce this behavior here.
         # See: https://github.com/huggingface/transformers/issues/1196
@@ -32,3 +54,24 @@ class Seq2RelDatasetReader(CopyNetDatasetReader):
         if _id is not None:
             instance.fields["metadata"].metadata["_id"] = _id
         return instance
+
+    def _head_tail_truncation(self, source_string: str) -> str:
+        """Truncates and returns `source_string` by concatenating the first 75% and last 25% of
+        `self._max_length` tokens. Accounts for special tokens added by the tokenizer. If
+        `source_string` is less than `self._max_length`, it is returned unmodified.
+        """
+        # Account for special tokens
+        max_length = self._max_length - self._source_tokenizer.num_special_tokens_for_sequence()
+        tokenized_source = self._source_tokenizer.tokenizer.tokenize(source_string)
+        if len(tokenized_source) > max_length:
+            # Truncate by concatenating the first 75% of tokens and the last 25% of tokens
+            head = floor(max_length * 0.75)
+            tail = floor(max_length * 0.25)
+            tail += max_length - head - tail
+            tokenized_source = (
+                tokenized_source[:head] + tokenized_source[len(tokenized_source) - tail :]
+            )
+            source_string = self._source_tokenizer.tokenizer.convert_tokens_to_string(
+                tokenized_source
+            )
+        return source_string

--- a/tests/test_dataset_reader.py
+++ b/tests/test_dataset_reader.py
@@ -1,0 +1,49 @@
+import pathlib
+
+import pytest
+from allennlp.common import Params
+from allennlp.common.testing import AllenNlpTestCase
+from allennlp.common.util import ensure_list
+from allennlp.data import DatasetReader
+from allennlp.data.vocabulary import Vocabulary
+from seq2rel.dataset_reader import Seq2RelDatasetReader
+
+
+class TestSeq2RelDatasetReader(AllenNlpTestCase):
+    def setup_method(self):
+        super().setup_method()
+        self.FIXTURES_ROOT = (pathlib.Path(__file__).parent / "..").resolve() / "test_fixtures"
+        params = Params.from_file(self.FIXTURES_ROOT / "experiment.jsonnet")
+        self.reader: Seq2RelDatasetReader = DatasetReader.from_params(params["dataset_reader"])
+        instances = self.reader.read(
+            self.FIXTURES_ROOT / "data" / "train.tsv",
+        )
+        self.instances = ensure_list(instances)
+        self.vocab = Vocabulary.from_params(params=params["vocabulary"], instances=self.instances)
+
+    def test_head_tail_truncation(self, params: Params) -> None:
+        max_length = 24
+        dataset_reader_params = params.pop("dataset_reader")
+        dataset_reader_params["max_length"] = max_length
+        reader = DatasetReader.from_params(dataset_reader_params)
+        source_string = (
+            "Anaphylaxis to cisplatin is an infrequent life-threatening complication which may"
+            " occur even in patients who have received prior treatment with cisplatin."
+        )
+
+        expected_string = "anaphylaxis to cisplatin is an infrequent life treatment with cisplatin."
+        expected_length = max_length - reader._target_tokenizer.num_special_tokens_for_sequence()
+
+        actual_string = reader._head_tail_truncation(source_string)
+        actual_length = len(reader._source_tokenizer.tokenizer.tokenize(actual_string))
+        assert actual_string == expected_string
+        assert actual_length == expected_length
+
+    def test_head_tail_truncation_value_error(self, params: Params) -> None:
+        max_length = 24
+        dataset_reader_params = params.pop("dataset_reader")
+        dataset_reader_params["max_length"] = max_length
+        dataset_reader_params["source_tokenizer"] = None
+        reader = DatasetReader.from_params(dataset_reader_params)
+        with pytest.raises(ValueError):
+            reader.text_to_instance("")


### PR DESCRIPTION
This PR adds an argument `max_length` to `Seq2RelDatasetReader` that supports head+tail truncation a la https://arxiv.org/abs/1905.05583. Basically, we truncate documents by taking the first `0.75 * max_length` tokens and the last `0.25 * max_length` tokens, accounting for any special tokens that the tokenizer may add. This captures the intuition that naively truncating documents at the end can be a bad strategy. For example, this would remove the conclusion section of a scientific abstract.