### PR TITLE
Remove duplicate ents

### DIFF
--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -85,7 +85,7 @@ def test_deserialize_annotation() -> None:
 
     # Set `ordered_ents=True` so that mentions aren't sorted (easier to write test cases).
     deduplicated_expected = copy.deepcopy(expected)
-    del deduplicated_expected[-1]["LOCATED_IN_THE_ADMINISTRATIVE_TERRITORIAL_ENTITY"][-1]
+    del deduplicated_expected[-1]["LOCATED_IN_THE_ADMINISTRATIVE_TERRITORIAL_ENTITY"][-1]  # type: ignore
     actual = util.deserialize_annotations(
         serialized_annotations, ordered_ents=True, remove_duplicate_ents=True
     )
@@ -114,5 +114,5 @@ def test_normalize_clusters() -> None:
         (("methamphetamine", "meth"), "CHEMICAL"),
         # The duplicate entity is removed because remove_duplicate_ents is True.
         (("psychotic disorders", "psychosis"), "DISEASE"),
-    )
+    )  # type: ignore
     assert actual == expected


### PR DESCRIPTION
This PR adds a keyword argument, `remove_duplicate_ents` which removes all non-unique entities from a relation prediction. By default, this is set to `False` as these are sometimes real relations (e.g. homodimers in protein-protein interactions).

However, for most datasets/tasks, they are incorrect, so filtering them before evaluation can improve performance. In practice, I find that this tends to have only a small positive impact on performance, suggesting that the model rarely generates relation strings with duplicate entities.