### PR TITLE
:wrench: Cap validation start at 0

### DIFF
--- a/test_fixtures/experiment.jsonnet
+++ b/test_fixtures/experiment.jsonnet
@@ -46,7 +46,7 @@ local validation_data_path = "test_fixtures/data/valid.tsv";
 local dataset_size = 1;
 
 // Validation begins at the end of the validation_start epoch...
-local validation_start = std.floor(num_epochs - 4);
+local validation_start = std.max(std.floor(num_epochs - 4), 0);
 // ...and continues for every validation_interval epochs after that
 local validation_interval = 1;
 

--- a/training_config/cdr.jsonnet
+++ b/training_config/cdr.jsonnet
@@ -46,7 +46,7 @@ local validation_data_path = std.extVar("valid_data_path");
 local dataset_size = std.parseInt(std.extVar('dataset_size'));
 
 // Validation begins at the end of the validation_start epoch...
-local validation_start = std.max(std.floor(num_epochs - 4), num_epochs);
+local validation_start = std.max(std.floor(num_epochs - 4), 0);
 // ...and continues for every validation_interval epochs after that
 local validation_interval = 1;
 

--- a/training_config/cdr.jsonnet
+++ b/training_config/cdr.jsonnet
@@ -46,7 +46,7 @@ local validation_data_path = std.extVar("valid_data_path");
 local dataset_size = std.parseInt(std.extVar('dataset_size'));
 
 // Validation begins at the end of the validation_start epoch...
-local validation_start = std.floor(num_epochs - 4);
+local validation_start = std.max(std.floor(num_epochs - 4), num_epochs);
 // ...and continues for every validation_interval epochs after that
 local validation_interval = 1;
 

--- a/training_config/cdr_hints.jsonnet
+++ b/training_config/cdr_hints.jsonnet
@@ -46,7 +46,7 @@ local validation_data_path = std.extVar("valid_data_path");
 local dataset_size = std.parseInt(std.extVar('dataset_size'));
 
 // Validation begins at the end of the validation_start epoch...
-local validation_start = std.floor(num_epochs - 6);
+local validation_start = std.max(std.floor(num_epochs - 6), 0);
 // ...and continues for every validation_interval epochs after that
 local validation_interval = 2;
 

--- a/training_config/dgm.jsonnet
+++ b/training_config/dgm.jsonnet
@@ -47,7 +47,7 @@ local validation_data_path = std.extVar("valid_data_path");
 local dataset_size = std.parseInt(std.extVar('dataset_size'));
 
 // Validation will begin at the end of this epoch.
-local validation_start = std.floor(num_epochs - 4);
+local validation_start = std.max(std.floor(num_epochs - 4), 0);
 // ...and continues for every validation_interval epochs after that
 local validation_interval = 1;
 

--- a/training_config/dgm_hints.jsonnet
+++ b/training_config/dgm_hints.jsonnet
@@ -47,7 +47,7 @@ local validation_data_path = std.extVar("valid_data_path");
 local dataset_size = std.parseInt(std.extVar('dataset_size'));
 
 // Validation will begin at the end of this epoch.
-local validation_start = std.floor(num_epochs - 4);
+local validation_start = std.max(std.floor(num_epochs - 4), 0);
 // ...and continues for every validation_interval epochs after that
 local validation_interval = 1;
 

--- a/training_config/docred.jsonnet
+++ b/training_config/docred.jsonnet
@@ -146,7 +146,7 @@ local validation_data_path = std.extVar("valid_data_path");
 local dataset_size = std.parseInt(std.extVar('dataset_size'));
 
 // Validation will begin at the end of this epoch.
-local validation_start = std.floor(num_epochs - 2);
+local validation_start = std.max(std.floor(num_epochs - 2), 0);
 // ...and continues for every validation_interval epochs after that
 local validation_interval = 1;
 

--- a/training_config/gda.jsonnet
+++ b/training_config/gda.jsonnet
@@ -46,7 +46,7 @@ local validation_data_path = std.extVar("valid_data_path");
 local dataset_size = std.parseInt(std.extVar('dataset_size'));
 
 // Validation will begin at the end of this epoch.
-local validation_start = std.floor(num_epochs - 2);
+local validation_start = std.max(std.floor(num_epochs - 2), 0);
 // ...and continues for every validation_interval epochs after that
 local validation_interval = 1;
 

--- a/training_config/gda_hints.jsonnet
+++ b/training_config/gda_hints.jsonnet
@@ -46,7 +46,7 @@ local validation_data_path = std.extVar("valid_data_path");
 local dataset_size = std.parseInt(std.extVar('dataset_size'));
 
 // Validation will begin at the end of this epoch.
-local validation_start = std.floor(num_epochs - 2);
+local validation_start = std.max(std.floor(num_epochs - 2), 0);
 // ...and continues for every validation_interval epochs after that
 local validation_interval = 1;
 


### PR DESCRIPTION
We had a line in all our configs that looked like this:

```jsonnet
# OLD
local validation_start = std.floor(num_epochs - 4);
```

However, this gave a negative `validation_start` when `num_epochs` is less than 4 (or whatever value is being subtract). A less error prone way to do this is to cap it as the max of `num_epochs - 4`, `0`:

```jsonnet
# NEW
local validation_start = std.max(std.floor(num_epochs - 4), 0);
```

The main motivation for adding this is that I am working on some colab notebooks which will serve as tutorials, and would like to set `num_epochs` to `1` without making any other changes to the config.